### PR TITLE
Store filter results in PHFlags, fix clang/cpp-check issues

### DIFF
--- a/Fun4All_TestBeamBackgroundFilterAndQA.C
+++ b/Fun4All_TestBeamBackgroundFilterAndQA.C
@@ -16,8 +16,8 @@
 #include <beambackgroundfilterandqa/BeamBackgroundFilterAndQA.h>
 #include <beambackgroundfilterandqa/NullFilter.h>
 #include <beambackgroundfilterandqa/StreakSidebandFilter.h>
+#include <beambackgroundfilterandqa/TestPHFlags.h>
 #include <ffamodules/CDBInterface.h>
-#include <ffamodules/FlagHandler.h>
 #include <FROG.h>
 #include <fun4all/Fun4AllDstInputManager.h>
 #include <fun4all/Fun4AllInputManager.h>
@@ -38,7 +38,7 @@ R__LOAD_LIBRARY(libfun4allraw.so)
 void Fun4All_TestBeamBackgroundFilterAndQA(
   const int runnumber = 47152,
   const int nEvents = 10,
-  const int verbosity = 5,
+  const int verbosity = 0,
   const std::string inFile = "DST_CALO_run2pp_ana437_2024p007-00047152-00160.root",
   const std::string outFile = "test_bbfaq.root"
 ) {
@@ -95,6 +95,10 @@ void Fun4All_TestBeamBackgroundFilterAndQA(
   filter -> SetConfig(cfg_filter);
   filter -> Verbosity(verbosity);
   f4a    -> registerSubsystem(filter);
+
+  // confirm that background flags exist
+  TestPHFlags* flags = new TestPHFlags("TestPHFlags");
+  f4a -> registerSubsystem(flags);
 
   // run modules and exit -----------------------------------------------------
 

--- a/scripts/copy-to-analysis.rb
+++ b/scripts/copy-to-analysis.rb
@@ -29,6 +29,8 @@ to_copy = [
   "src/NullFilter.h",
   "src/StreakSidebandFilter.cc",
   "src/StreakSidebandFilter.h",
+  "src/TestPHFlags.cc",
+  "src/TestPHFlags.h",
   "src/autogen.sh",
   "src/configure.ac",
   "src/Makefile.am",

--- a/src/BaseBeamBackgroundFilter.h
+++ b/src/BaseBeamBackgroundFilter.h
@@ -94,7 +94,7 @@ class BaseBeamBackgroundFilter
 
     ///! default ctor/dtor
     BaseBeamBackgroundFilter()  {};
-    ~BaseBeamBackgroundFilter() {};
+    virtual ~BaseBeamBackgroundFilter() {};
 
 };  // end BaseBeamBackgroundFilter
 

--- a/src/BeamBackgroundFilterAndQA.cc
+++ b/src/BeamBackgroundFilterAndQA.cc
@@ -47,7 +47,8 @@ namespace bbfqd = BeamBackgroundFilterAndQADefs;
 // ----------------------------------------------------------------------------
 //! Default module constructor
 // ----------------------------------------------------------------------------
-BeamBackgroundFilterAndQA::BeamBackgroundFilterAndQA(const std::string& name, const bool debug) : SubsysReco(name)
+BeamBackgroundFilterAndQA::BeamBackgroundFilterAndQA(const std::string& name, const bool debug)
+  : SubsysReco(name)
 {
 
   // print debug message
@@ -63,11 +64,11 @@ BeamBackgroundFilterAndQA::BeamBackgroundFilterAndQA(const std::string& name, co
 // ----------------------------------------------------------------------------
 //! Module constructor accepting a configuration
 // ----------------------------------------------------------------------------
-BeamBackgroundFilterAndQA::BeamBackgroundFilterAndQA(const Config& config) : SubsysReco(config.moduleName)
+BeamBackgroundFilterAndQA::BeamBackgroundFilterAndQA(const Config& config)
+  : SubsysReco(config.moduleName)
+  , m_manager(nullptr)
+  , m_config(config)
 {
-
-  // set configuration
-  m_config = config;
 
   // print debug message
   if (m_config.debug && (Verbosity() > 0))

--- a/src/BeamBackgroundFilterAndQA.cc
+++ b/src/BeamBackgroundFilterAndQA.cc
@@ -21,11 +21,13 @@
 // f4a libraries
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllHistoManager.h>
+#include <ffaobjects/FlagSavev1.h>
 
 // phool libraries
 #include <phool/getClass.h>
 #include <phool/phool.h>
 #include <phool/PHCompositeNode.h>
+#include <phool/recoConsts.h>
 
 // qa utilities
 #include <qautils/QAHistManagerDef.h>
@@ -67,6 +69,7 @@ BeamBackgroundFilterAndQA::BeamBackgroundFilterAndQA(const std::string& name, co
 BeamBackgroundFilterAndQA::BeamBackgroundFilterAndQA(const Config& config)
   : SubsysReco(config.moduleName)
   , m_manager(nullptr)
+  , m_consts(nullptr)
   , m_config(config)
 {
 
@@ -111,8 +114,9 @@ int BeamBackgroundFilterAndQA::Init(PHCompositeNode* /*topNode*/)
     std::cout << "BeamBackgroundFilterAndQA::Init(PHCompositeNode *topNode) Initializing" << std::endl;
   }
 
-  // initialize relevant filters
+  // initialize relevant filters, histograms
   InitFilters();
+  InitFlags();
   BuildHistograms();
 
   // if needed, initialize histograms + manager
@@ -140,6 +144,12 @@ int BeamBackgroundFilterAndQA::process_event(PHCompositeNode* topNode)
 
   // check for beam background
   const bool hasBeamBkgd = ApplyFilters(topNode);
+
+  // if debugging, print out flags
+  if (m_config.debug)
+  {
+    m_consts->PrintIntFlags();
+  }
 
   // if it does, abort event
   if (hasBeamBkgd && m_config.doEvtAbort)
@@ -187,13 +197,36 @@ void BeamBackgroundFilterAndQA::InitFilters()
     std::cout << "BeamBackgroundFilterAndQA::InitFilters() Initializing background filters" << std::endl;
   }
 
-  m_filters["Null"] = std::make_unique<NullFilter>( m_config.null );
+  m_filters["Null"] = std::make_unique<NullFilter>( m_config.null, "Null" );
   m_filters["StreakSideband"] = std::make_unique<StreakSidebandFilter>( m_config.sideband, "StreakSideband" );
   //... other filters added here ...//
-
   return;
 
 }  // end 'InitFilters()'
+
+
+
+// ----------------------------------------------------------------------------
+//! Initialize flags
+// ----------------------------------------------------------------------------
+void BeamBackgroundFilterAndQA::InitFlags()
+{
+
+  // print debug message
+  if (m_config.debug && (Verbosity() > 1))
+  {
+    std::cout << "BeamBackgroundFilterAndQA::InitFlags() Initializing reco consts and flags" << std::endl;
+  }
+
+  m_consts = recoConsts::instance();
+  for (const std::string& filterToApply : m_config.filtersToApply)
+  {
+    m_consts->set_IntFlag("HasBeamBackground_" + filterToApply + "Filter", 0);
+  }
+  m_consts->set_IntFlag("HasBeamBackground", 0);
+  return;
+
+}  // end 'InitFlags()'
 
 
 
@@ -304,6 +337,7 @@ bool BeamBackgroundFilterAndQA::ApplyFilters(PHCompositeNode* topNode)
     std::cout << "BeamBackgroundFilterAndQA::ApplyFilters(PHCompositeNode*) Creating histograms" << std::endl;
   }
 
+  // apply individual filters 
   bool hasBkgd = false;
   for (const std::string& filterToApply : m_config.filtersToApply)
   {
@@ -311,6 +345,7 @@ bool BeamBackgroundFilterAndQA::ApplyFilters(PHCompositeNode* topNode)
     if (filterFoundBkgd)
     {
       m_hists["nevts_" + filterToApply]->Fill(bbfqd::Status::HasBkgd);
+      m_consts->set_IntFlag("HasBeamBackground_" + filterToApply + "Filter", 1);
     }
     else
     {
@@ -325,6 +360,7 @@ bool BeamBackgroundFilterAndQA::ApplyFilters(PHCompositeNode* topNode)
   if (hasBkgd)
   {
     m_hists["nevts_overall"]->Fill(bbfqd::Status::HasBkgd);
+    m_consts->set_IntFlag("HasBeamBackground", 1);
   }
   else
   {

--- a/src/BeamBackgroundFilterAndQA.h
+++ b/src/BeamBackgroundFilterAndQA.h
@@ -30,6 +30,7 @@
 class Fun4AllHistoManager;
 class PHCompositeNode;
 class QAHistManagerHistDef;
+class recoConsts;
 class TowerInfoContainer;
 
 
@@ -92,6 +93,7 @@ class BeamBackgroundFilterAndQA : public SubsysReco {
 
     // private methods
     void InitFilters();
+    void InitFlags();
     void InitHistManager();
     void BuildHistograms();
     void RegisterHistograms();
@@ -99,6 +101,9 @@ class BeamBackgroundFilterAndQA : public SubsysReco {
 
     ///! histogram manager
     Fun4AllHistoManager* m_manager;
+
+    ///! reco consts (for flags)
+    recoConsts* m_consts;
 
     ///! module-wide histograms
     std::map<std::string, TH1*> m_hists;

--- a/src/BeamBackgroundFilterAndQA.h
+++ b/src/BeamBackgroundFilterAndQA.h
@@ -98,7 +98,7 @@ class BeamBackgroundFilterAndQA : public SubsysReco {
     bool ApplyFilters(PHCompositeNode* topNode);
 
     ///! histogram manager
-    Fun4AllHistoManager* m_manager = NULL;
+    Fun4AllHistoManager* m_manager;
 
     ///! module-wide histograms
     std::map<std::string, TH1*> m_hists;

--- a/src/BeamBackgroundFilterAndQADefs.h
+++ b/src/BeamBackgroundFilterAndQADefs.h
@@ -140,7 +140,7 @@ namespace BeamBackgroundFilterAndQADefs {
    *  FIXME this should get moved into JetQADefs.h
    */
   inline std::vector<std::string> MakeQAHistNames(
-    const std::vector<std::string> bases,
+    const std::vector<std::string>& bases,
     const std::string& module,
     const std::string& tag = ""
   ) {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,7 +18,8 @@ pkginclude_HEADERS = \
   BeamBackgroundFilterAndQADefs.h \
   BaseBeamBackgroundFilter.h \
   NullFilter.h \
-  StreakSidebandFilter.h
+  StreakSidebandFilter.h \
+  TestPHFlags.h
 
 if ! MAKEROOT6
   ROOT5_DICTS = \
@@ -29,7 +30,8 @@ libbeambackgroundfilterandqa_la_SOURCES = \
   $(ROOT5_DICTS) \
   BeamBackgroundFilterAndQA.cc \
   NullFilter.cc \
-  StreakSidebandFilter.cc
+  StreakSidebandFilter.cc \
+  TestPHFlags.cc
 
 libbeambackgroundfilterandqa_la_LDFLAGS = \
   -L$(libdir) \

--- a/src/NullFilter.cc
+++ b/src/NullFilter.cc
@@ -43,10 +43,10 @@ NullFilter::NullFilter(const std::string& name)
 //! ctor accepting config struct
 // ----------------------------------------------------------------------------
 NullFilter::NullFilter(const Config& config, const std::string& name)
+  : m_config(config)
 {
 
-  m_config = config;
-  m_name   = name;
+  m_name = name;
 
 }  // end ctor(Config&)
 

--- a/src/StreakSidebandFilter.cc
+++ b/src/StreakSidebandFilter.cc
@@ -38,6 +38,7 @@
 //! Default ctor
 // ----------------------------------------------------------------------------
 StreakSidebandFilter::StreakSidebandFilter(const std::string& name)
+  : m_ohContainer(nullptr)
 {
 
   m_name = name;
@@ -50,10 +51,11 @@ StreakSidebandFilter::StreakSidebandFilter(const std::string& name)
 //! ctor accepting config struct
 // ----------------------------------------------------------------------------
 StreakSidebandFilter::StreakSidebandFilter(const Config& config, const std::string& name)
+  : m_ohContainer(nullptr)
+  , m_config(config)
 {
 
-  m_config = config;
-  m_name   = name;
+  m_name = name;
 
 }  // end ctor(Config&)
 

--- a/src/TestPHFlags.cc
+++ b/src/TestPHFlags.cc
@@ -1,0 +1,109 @@
+/// ===========================================================================
+/*! \file    TestPHFlags.cc
+ *  \authors Derek Anderson
+ *  \date    11.22.2024
+ *
+ *  A small F4A module to test if certain
+ *  flags exist.
+ */
+/// ===========================================================================
+
+#define TESTPHFLAGS_CC
+
+// module definition
+#include "TestPHFlags.h"
+
+// c++ utilities
+#include <iostream>
+#include <vector>
+
+// f4a libraries
+#include <fun4all/Fun4AllReturnCodes.h>
+//#include <ffaobjects/FlagSave.h>
+#include <ffaobjects/FlagSavev1.h>
+#include <phool/recoConsts.h>
+
+// phool libraries
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHFlag.h>
+
+
+
+// ctor/dtor ==================================================================
+
+// ----------------------------------------------------------------------------
+//! Default module constructor
+// ----------------------------------------------------------------------------
+TestPHFlags::TestPHFlags(const std::string& name, const bool debug)
+  : SubsysReco(name)
+  , m_consts(nullptr)
+  , m_doDebug(debug)
+{
+
+  if (m_doDebug)
+  {
+    std::cout << "TestPHFlags::TestPHFlags(const std::string &name) Calling ctor" << std::endl;
+  }
+
+}  // end ctor(std::string&, bool)
+
+
+
+// ----------------------------------------------------------------------------
+//! Default module destructor
+// ----------------------------------------------------------------------------
+TestPHFlags::~TestPHFlags()
+{
+
+  if (m_doDebug)
+  {
+    std::cout << "TestPHFlags::~TestPHFlags() Calling dtor" << std::endl;
+  }
+
+}  // end dtor
+
+
+// fun4all methods ============================================================ 
+
+// ----------------------------------------------------------------------------
+//! Process event, i.e. spit out the values of several flags
+// ----------------------------------------------------------------------------
+int TestPHFlags::process_event(PHCompositeNode* topNode)
+{
+
+  if (m_doDebug)
+  {
+    std::cout << "TestPHFlags::process_event(PHCompositeNode *topNode) Processing Event" << std::endl;
+  }
+
+  // instantiate flags database
+  // and print all int flags
+  m_consts = recoConsts::instance();
+  m_consts->PrintIntFlags();
+
+  // and then explicitly look for these flags
+  std::vector<std::string> flagsToCheck = {
+    "HasBeamBackground_NullFilter",
+    "HasBeamBackground_StreakSidebandFilter",
+    "HasBeamBackground"
+  };
+
+  // if flag exists, print value
+  for (const std::string& flag : flagsToCheck)
+  {
+    std::cout << "[" << flag << "] exists? " << m_consts->FlagExist(flag);
+    if (m_consts->FlagExist(flag))
+    {
+      std::cout << " : value = " << m_consts->get_IntFlag(flag) << std::endl;
+    }
+    else
+    {
+      std::cout << std::endl;
+    }
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+
+}  // end 'process_event(PHCompositeNode*)'
+
+// end ========================================================================

--- a/src/TestPHFlags.h
+++ b/src/TestPHFlags.h
@@ -1,0 +1,59 @@
+// Tell emacs that this is a C++ source
+//  -*- C++ -*-.
+/// ===========================================================================
+/*! \file    TestPHFlags.h
+ *  \authors Derek Anderson
+ *  \date    11.22.2024
+ *
+ *  A small F4A module to test if certain
+ *  flags exist.
+ */
+/// ===========================================================================
+
+#ifndef TESTPHFLAGS_H
+#define TESTPHFLAGS_H
+
+// c++ utilities
+#include <string>
+
+// f4a libraries
+#include <fun4all/SubsysReco.h>
+
+// forward declarations
+class FlagSavev1;
+class PHCompositeNode;
+class recoConsts;
+
+
+
+// ============================================================================
+//! Test certain PHFlags
+// ============================================================================
+/*! A small F4A module to test if certain
+ *  flags exist.
+ */
+class TestPHFlags : public SubsysReco
+{
+
+  public:
+
+    // ctor/dtor
+    TestPHFlags(const std::string &name = "TestPHFlags", const bool debug = false);
+    ~TestPHFlags() override;
+
+    // f4a methods
+    int process_event(PHCompositeNode *topNode) override;
+
+   private:
+
+     ///! reco consts (for flags)
+     recoConsts* m_consts;
+
+     ///! turn on/off extra debugging messages
+     bool m_doDebug;
+
+};  // end TestPHFlags
+
+#endif
+
+// end ========================================================================

--- a/src/TestPHFlagsLinkDef.h
+++ b/src/TestPHFlagsLinkDef.h
@@ -1,0 +1,19 @@
+/// ===========================================================================
+/*! \file    TestPHFlagsLinkDef.h
+ *  \authors Derek Anderson
+ *  \date    11.22.2024
+ *
+ *  A small F4A module to test if certain
+ *  flags exist.
+ */
+/// ===========================================================================
+
+#pragma once
+
+#ifdef __CINT__
+
+#pragma link C++ class TestPHFlagsLinkDef
+
+#endif  // end if __CINT__
+
+// end ========================================================================


### PR DESCRIPTION
This PR accomplishes 2 goals: being able to pass filter results to downstream modules, and fixing previously undetected issues with `clang` and `cpp-check`. Details:

1. To accomplish the former goal, the results of each filter (and overall) are stored in `PHFlag`s and saved to `recoConsts`, which enables the user to identify events in which beam background was identified in downstream modules. An additional module (`TestPHFlags`) has been added as an example of how to access the flags in a downstream module.
2. And to accomplish the latter, the dtor of `BaseBeamBackgroundFilter` has been made virtual and initialization lists are now preferred where relevant.